### PR TITLE
fix: fixed name tag capitalization so it shows up appropriately in console

### DIFF
--- a/cream-network-template.yaml
+++ b/cream-network-template.yaml
@@ -21,5 +21,5 @@ Resources:
     Properties:
       CidrBlock: 10.0.0.0/16
       Tags:
-        - Key: name
+        - Key: Name
           Value: !Sub "${ProjectName}-VPC"


### PR DESCRIPTION
Context:
There's an issue with capitalization in the "Name" tag so it doesn't appear correctly in the console

How it appears now:
![image](https://github.com/user-attachments/assets/5c2a892f-940c-425e-92af-a8b9a6582a72)

It should display the value of the "Name" tag, but because we're setting "name" instead of "Name" it does not display.

Changes:
- Changed "name" to "Name"